### PR TITLE
Escape strings with three quotes instead of one

### DIFF
--- a/escape_helpers.py
+++ b/escape_helpers.py
@@ -23,7 +23,7 @@ def sparql_escape_string(obj):
     obj = str(obj)
     def replacer(a):
         return "\\"+a.group(0)
-    return '"' + re.sub(r'[\\\'"]', replacer, obj) + '"'
+    return '"""' + re.sub(r'[\\\'"]', replacer, obj) + '"""'
 
 def sparql_escape_datetime(obj):
     obj = datetime.strptime(str(obj))


### PR DESCRIPTION
Virtuoso doesn't accept single quoted strings that have new lines
inside. By using three quotes to escape them, this case is handled.